### PR TITLE
return context at end of execution of function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ var FunctionHarness = function(nameOrPath, config) {
                                 invoke.bindings[name] = results[name];
                             }
 
-                            resolve(invoke.context.bindings);
+                            resolve(invoke.context);
                         }
                     },
                     log: function(log) {

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ var FunctionHarness = function(nameOrPath, config) {
                         invoke.bindings[name] = results[name];
                     }
 
-                    cb(invoke.context.bindings);
+                    cb(invoke.context);
                 },
                 log: function(log) {
                     console.log(log);


### PR DESCRIPTION
By returning the context instead of just the bindings so we can enable scenarios in HTTP triggers.  The bindings will still be available to test against.  

For example in the function:

```javascript
module.exports = function (context, req) {

if (!req.body.poolId || validator.isEmpty(req.body.poolid)){
    context.res = { status: 400, body: 'must pass poolid' }; 
    context.done();
    return;
}

#rest of function
```

can be tested:

```javascript
funcToTest.invoke({
      req: request
}).then(context => {
    t.equal(400, context.res.status);
}).catch(err =>{
    t.fail(`something went wrong: ${err}`);
});
```